### PR TITLE
added staabm/phpstan-todo-by example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently, if you publish/offer a crate and a todo_by expires in the lib code, t
 
 ### You might find useful
 
-Here're some alternative implementations for other languages and tools:
+Here are some alternative implementations for other languages and tools. These are not directly affiliated and software should always be vetted for trustworthiness, including this Rust `todo_by` crate! That said, great work by these authors.
 
 - [no-expired-todo-comments](https://github.com/maxprilutskiy/eslint-plugin-no-expired-todo-comments) - ESLint plugin by [@MaxPrilutskiy](https://twitter.com/MaxPrilutskiy)
 - [staabm/phpstan-todo-by](https://github.com/staabm/phpstan-todo-by) - PHPStan plugin by [@staabm](https://twitter.com/markusstaab)

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Currently, if you publish/offer a crate and a todo_by expires in the lib code, t
 Here're some alternative implementations for other languages and tools:
 
 - [no-expired-todo-comments](https://github.com/maxprilutskiy/eslint-plugin-no-expired-todo-comments) - ESLint plugin by [@MaxPrilutskiy](https://twitter.com/MaxPrilutskiy)
+- [staabm/phpstan-todo-by](https://github.com/staabm/phpstan-todo-by) - PHPStan plugin by [@staabm](https://twitter.com/markusstaab)


### PR DESCRIPTION
inspired by your great plugin I recently ported the idea to PHP.

it is implemented as a PHPStan extension, which means the comments are checked for expiration as part of a static analsis process

see also related blog post: https://staabm.github.io/2023/12/17/phpstan-todo-by-published.html